### PR TITLE
add apt-get update, otherwise first apt-get install will fail

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+set -x
+
 # Install some additional drivers, including support for FTDI dongles
 # http://askubuntu.com/questions/541443/how-to-install-usbserial-and-ftdi-sio-modules-to-14-04-trusty-vagrant-box
+sudo apt-get update -qq
 sudo apt-get install -y linux-image-extra-virtual
 sudo modprobe ftdi_sio vendor=0x0403 product=0x6001
 
@@ -19,7 +22,7 @@ sudo modprobe ftdi_sio vendor=0x0403 product=0x6001
 
 # Install basic development tools
 sudo dpkg --add-architecture i386
-sudo apt-get update
+sudo apt-get update -qq
 sudo apt-get install -y build-essential autotools-dev autoconf pkg-config libusb-1.0-0 libusb-1.0-0-dev libftdi1 libftdi-dev git libc6:i386 libncurses5:i386 libstdc++6:i386 cowsay figlet language-pack-en
 sudo locale-gen UTF-8
 


### PR DESCRIPTION
without an initial `apt-get update`, the first `apt-get install` command will fail:

```
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: 
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   crda iw libnl-3-200 libnl-genl-3-200 linux-firmware
==> default:   linux-image-extra-3.13.0-74-generic linux-image-generic wireless-regdb
==> default: The following NEW packages will be installed:
==> default:   crda iw libnl-3-200 libnl-genl-3-200 linux-firmware
==> default:   linux-image-extra-3.13.0-74-generic linux-image-extra-virtual
==> default:   linux-image-generic wireless-regdb
==> default: 0 upgraded, 9 newly installed, 0 to remove and 0 not upgraded.
==> default: Need to get 61.4 MB of archives.
==> default: After this operation, 238 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libnl-3-200 amd64 3.2.21-1 [44.5 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main libnl-genl-3-200 amd64 3.2.21-1 [10.2 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty/main wireless-regdb all 2013.02.13-1ubuntu1 [6,456 B]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty/main crda amd64 1.1.2-1ubuntu2 [15.2 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main iw amd64 3.4-1 [51.7 kB]
==> default: Err http://archive.ubuntu.com/ubuntu/ trusty-updates/main linux-firmware all 1.127.19
==> default:   404  Not Found [IP: 91.189.91.24 80]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty-updates/main linux-image-extra-3.13.0-74-generic amd64 3.13.0-74.118 [36.8 MB]
==> default: Err http://archive.ubuntu.com/ubuntu/ trusty-updates/main linux-image-generic amd64 3.13.0.74.80
==> default:   404  Not Found [IP: 91.189.91.24 80]
==> default: Err http://security.ubuntu.com/ubuntu/ trusty-security/main linux-image-generic amd64 3.13.0.74.80
==> default:   404  Not Found [IP: 91.189.91.23 80]
==> default: Err http://security.ubuntu.com/ubuntu/ trusty-security/main linux-image-extra-virtual amd64 3.13.0.74.80
==> default:   404  Not Found [IP: 91.189.91.23 80]
==> default: Fetched 36.9 MB in 4s (8,949 kB/s)
==> default: E
==> default: : 
==> default: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/l/linux-firmware/linux-firmware_1.127.19_all.deb  404  Not Found [IP: 91.189.91.24 80]
==> default: E
==> default: : 
==> default: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux-meta/linux-image-generic_3.13.0.74.80_amd64.deb  404  Not Found [IP: 91.189.91.23 80]
==> default: E
==> default: : 
==> default: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux-meta/linux-image-extra-virtual_3.13.0.74.80_amd64.deb  404  Not Found [IP: 91.189.91.23 80]
==> default: E
==> default: : 
==> default: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
==> default: modprobe: FATAL: Module ftdi_sio not found.
```