### PR TITLE
split out the toolchain setup from the repo setup

### DIFF
--- a/0_install-toolchain.sh
+++ b/0_install-toolchain.sh
@@ -2,6 +2,15 @@
 
 set -x
 
+# fix apt warnings like:
+# ==> default: dpkg-preconfigure: unable to re-open stdin: No such file or directory
+# http://serverfault.com/questions/500764/dpkg-reconfigure-unable-to-re-open-stdin-no-file-or-directory
+export LANGUAGE=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+locale-gen en_US.UTF-8
+dpkg-reconfigure locales
+
 # Install some additional drivers, including support for FTDI dongles
 # http://askubuntu.com/questions/541443/how-to-install-usbserial-and-ftdi-sio-modules-to-14-04-trusty-vagrant-box
 sudo apt-get update -qq
@@ -11,7 +20,7 @@ sudo modprobe ftdi_sio vendor=0x0403 product=0x6001
 # Install FTDI lib
 # cd /home/vagrant
 # wget -nv http://www.ftdichip.com/Drivers/D2XX/Linux/libftd2xx-x86_64-1.3.6.tgz
-# tar xvf libftd2xx-x86_64-1.3.6.tgz
+# tar xfz libftd2xx-x86_64-1.3.6.tgz
 # cd release/build
 # cp -r lib* /usr/local/lib
 # chmod 0755 /usr/local/lib/libftd2xx.so.1.3.6
@@ -38,8 +47,8 @@ sudo ln -s /usr /usr/local/CrossPack-AVR
 
 # Install openocd
 cd /home/vagrant
-wget -nv http://downloads.sourceforge.net/project/openocd/openocd/0.9.0/openocd-0.9.0.tar.gz
-tar xvfz openocd-0.9.0.tar.gz
+wget -nv https://downloads.sourceforge.net/project/openocd/openocd/0.9.0/openocd-0.9.0.tar.gz
+tar xfz openocd-0.9.0.tar.gz
 cd openocd-0.9.0
 ./configure --enable-ftdi --enable-legacy-ft2232-libftdi --enable-stlink
 make
@@ -50,8 +59,8 @@ rm *.tar.gz
 
 # Install stlink
 cd /home/vagrant
-wget https://github.com/texane/stlink/archive/1.1.0.tar.gz
-tar xvfz 1.1.0.tar.gz
+wget -nv https://github.com/texane/stlink/archive/1.1.0.tar.gz
+tar xfz 1.1.0.tar.gz
 cd stlink-1.1.0
 ./autogen.sh
 ./configure
@@ -82,30 +91,7 @@ rm *.tar.bz2
 # this gcc version instead of 4.5.2).
 ln -s /usr/local/arm-4.8.3 /usr/local/arm
 
-# Code is stored in the VM itself
-# CODE_DIRECTORY=/home/vagrant
-# Code is stored in a directory shared between the VM and the host.
-CODE_DIRECTORY=/vagrant
-
-# Get modules source code
-cd $CODE_DIRECTORY
-USER_GITHUB_URL=$1
-if [ $USER_GITHUB_URL ]
-then
-  # Get from a clone of the original repo.
-  sudo -s -u vagrant -H git clone $USER_GITHUB_URL eurorack-modules
-  cd $CODE_DIRECTORY/eurorack-modules
-  sudo -s -u vagrant -H git remote add pichenettes https://github.com/pichenettes/eurorack.git
-else
-  # Get from the original repo.
-  sudo -s -u vagrant -H git clone https://github.com/pichenettes/eurorack.git eurorack-modules
-  cd $CODE_DIRECTORY/eurorack-modules
-fi
-sudo -s -u vagrant -H git submodule init
-sudo -s -u vagrant -H git submodule update
-
-# Add . to PYTHONPATH
+# Add "." to PYTHONPATH, and set default language
 echo 'export LC_ALL=en_US.UTF-8' >> /home/vagrant/.bashrc
 echo 'export LANGUAGE=en_US' >> /home/vagrant/.bashrc
 echo 'export PYTHONPATH=.:$PYTHONPATH' >> /home/vagrant/.bashrc
-echo "cd $CODE_DIRECTORY/eurorack-modules" >> /home/vagrant/.bashrc

--- a/1_clone-code.sh
+++ b/1_clone-code.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Code is stored in the VM itself
+# CODE_DIRECTORY=/home/vagrant
+# Code is stored in a directory shared between the VM and the host.
+CODE_ROOT=/vagrant
+WORKING_DIR_NAME=eurorack-modules
+DEV_ENV="${CODE_ROOT}/${WORKING_DIR_NAME}"
+MI_REPO="https://github.com/pichenettes/eurorack.git"
+
+# test if the dev_env directory already exists
+if [ -d "$DEV_ENV" ]; then
+    echo "WARNING: Working directory ${DEV_ENV} already exists, skipping git clone"
+else
+    # Clone the modules source code. If there was a alternative git URL
+    # provided as an argument to this script, than it will be clone.
+    # Otherwise, the default MI repo will be cloned.
+    cd $CODE_ROOT
+    USER_GITHUB_URL=$1
+    if [ $USER_GITHUB_URL ]; then
+        # Get from a clone of the custom repo.
+        git clone $USER_GITHUB_URL $WORKING_DIR_NAME
+        cd $DEV_ENV
+        git remote add pichenettes $MI_REPO
+    else
+        # Get from the original repo.
+        git clone $MI_REPO $WORKING_DIR_NAME
+        cd $DEV_ENV
+    fi
+    git submodule init
+    git submodule update
+fi
+
+# after logging in, cd directly to the code directory
+echo "cd $DEV_ENV" >> ~/.bashrc

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,5 +62,5 @@ Vagrant.configure(2) do |config|
 
   # provisioning scripts
   config.vm.provision :shell, path: "0_install-toolchain.sh"
-  config.vm.provision :shell, path: "1_clone-code.sh", args: "#{ENV['USER_GITHUB_URL']}"
+  config.vm.provision :shell, path: "1_clone-code.sh", args: "#{ENV['USER_GITHUB_URL']}", privileged: false
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,8 +60,7 @@ Vagrant.configure(2) do |config|
    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'FTDI serial adapter', '--vendorid', '0x0403', '--productid', '0x6001']
   end
 
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  config.vm.provision :shell, path: "bootstrap.sh", args: "#{ENV['USER_GITHUB_URL']}"
+  # provisioning scripts
+  config.vm.provision :shell, path: "0_install-toolchain.sh"
+  config.vm.provision :shell, path: "1_clone-code.sh", args: "#{ENV['USER_GITHUB_URL']}"
 end


### PR DESCRIPTION
For easier maintainability, I've split out the code for installing toolchain utilities from cloning the repo, and added a check to see if the code directory exists before trying to clone it again.