### PR TITLE
clarify that one has to clone the mutable-dev-environment repo first

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ Then **log out and log back in** to make sure the group change takes effect.
 
 ## Usage
 
-To start the VM, open a terminal in the directory with the Vagrantfile and run:
+First, clone this repository:
+
+	git clone https://github.com/pichenettes/mutable-dev-environment.git
+
+or download: 
+
+	https://github.com/pichenettes/mutable-dev-environment/archive/master.zip
+
+To start the VM, open a terminal in the `mutable-dev-environment` directory with the Vagrantfile and run:
 
     vagrant up
 


### PR DESCRIPTION
I have seen users follow the instructions without realizing they need
to do that first.

Signed-off-by: Vladimir Pantelic <vladimir@pantelic.net>