### PR TITLE
Updated OpenOCD to version 0.11.0

### DIFF
--- a/0_install-toolchain.sh
+++ b/0_install-toolchain.sh
@@ -44,14 +44,14 @@ sudo ln -s /usr /usr/local/CrossPack-AVR
 
 # Install openocd
 cd /home/vagrant
-wget -nv https://downloads.sourceforge.net/project/openocd/openocd/0.9.0/openocd-0.9.0.tar.gz
-tar xfz openocd-0.9.0.tar.gz
-cd openocd-0.9.0
+wget -nv https://downloads.sourceforge.net/project/openocd/openocd/0.11.0/openocd-0.11.0.tar.gz
+tar xfz openocd-0.11.0.tar.gz
+cd openocd-0.11.0
 ./configure --enable-ftdi --enable-stlink
 make
 sudo make install
 cd /home/vagrant
-rm -rf openocd-0.9.0
+rm -rf openocd-0.11.0
 rm *.tar.gz
 
 # Install stlink


### PR DESCRIPTION
`vagrant up` and `vagrant ssh` now shows the new version:
```
openocd vagrant@vagrant-ubuntu-trusty-64:/vagrant/eurorack-modules$ openocd --version
Open On-Chip Debugger 0.11.0
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
```