### PR TITLE
Updated USB product ID for new STLINK-V3 firmware

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure(2) do |config|
    vb.customize ['modifyvm', :id, '--usb', 'on']
    vb.customize ['modifyvm', :id, '--usbehci', 'on']
    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'STLink', '--vendorid', '0x0483', '--productid', '0x3748']
-   vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'STLINK-V3', '--vendorid', '0x0483', '--productid', '0x374f']
+   vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'STLINK-V3', '--vendorid', '0x0483', '--productid', '0x3753']
    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'Olimex OpenOCD JTAG ARM-USB-TINY-H', '--vendorid', '0x15BA', '--productid', '0x002a']
    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'Olimex OpenOCD JTAG ARM-USB-OCD-H', '--vendorid', '0x15BA', '--productid', '0x002b']
    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'Olimex OpenOCD JTAG', '--vendorid', '0x15BA', '--productid', '0x0003']


### PR DESCRIPTION
Updated programmer firmware to version `V3J7M3B5S1`, which now works reliable with OpenOCD:
```
Info : STLINK V3J7M3B5S1 (API v3) VID:PID 0483:3753
```